### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=linux/amd64 fedora:41
+
+RUN dnf install -y coreutils sed grep findutils gettext jq curl helm \
+  && curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz \
+  | tar -xz -C /usr/local/bin oc \
+  && chmod +x /usr/local/bin/oc \
+  && dnf clean all
+
+WORKDIR /app
+
+COPY . /app
+
+RUN chmod +x /app/start.sh
+
+ENTRYPOINT ["bash", "/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you prefer containerized execution, use this instead of the local installatio
 
 ```bash
 docker compose build
-docker compose up rhdh-deploy
+docker compose up rhdh-start
 ```
 
 - Teardown when done:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ The `/auth` directory is intended to store sensitive configuration files used by
 
 More details about this directory and how to populate it are provided in the plugin specific documentation.
 
-## First Steps
+## Running the Scripts
+
+You have two options to run these scripts:
+
+1. **Locally** - Install dependencies (`oc`, `helm`) and run directly
+2. **Docker** - Use containerized environment (especially useful for macOS users)
+
+## First Steps (Local Installation)
 
 These scripts are designed to work out-of-the-box with minimal setup. In fact, it's recommended that you start with the default setup to better understand how everything fits together. You can always customize and extend things later.
 
@@ -117,6 +124,24 @@ Step 6. Access your RHDH instance:
 - Once deployment is complete, navigate to the exposed route for RHDH in your OpenShift cluster (this is typically displayed in the script output).
 
 You'll now have a clean, working instance of RHDH that's ready to be enhanced in the next steps
+
+## Alternative: Run with Docker
+
+If you prefer containerized execution, use this instead of the local installation above:
+
+- Prereqs: Docker, `.env` configured (see Steps 3–4 from local installation).
+- First time setup:
+
+```bash
+docker compose build
+docker compose up rhdh-deploy
+```
+
+- Teardown when done:
+
+```bash
+docker compose up rhdh-teardown
+```
 
 ## Next Steps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+x-rhdh-base: &rhdh-base
+  build:
+    context: .
+    dockerfile: Dockerfile
+  platform: linux/amd64
+  volumes:
+    - .:/app
+    - auth-cluster-secrets:/app/auth/cluster-secrets
+    - ~/.kube:/root/.kube
+    - ~/.helm:/root/.helm
+  stdin_open: true
+  tty: true
+
+services:
+  rhdh-start:
+    <<: *rhdh-base
+    entrypoint: ["bash", "/app/start.sh"]
+
+  rhdh-teardown:
+    <<: *rhdh-base
+    entrypoint: ["bash", "/app/teardown.sh"]
+
+volumes:
+  auth-cluster-secrets:


### PR DESCRIPTION
On macOS, the scripts wouldn’t run due to platform incompatibilities. I added a Dockerfile and docker-compose setup to run them in a Fedora container, resolving the issue and providing consistent, reproducible execution. I also updated the README with usage instructions.

If you have any ideas or suggestions regarding these changes, I'll be very glad for feedback.