### PR TITLE
Ensure that we update all HELM_CHART_VERSION lines

### DIFF
--- a/.github/workflows/update-rhdh-version.yaml
+++ b/.github/workflows/update-rhdh-version.yaml
@@ -2,11 +2,11 @@ name: Update RHDH Version
 
 on:
   schedule:
-    - cron: '0 9 * * 1' # Weekly on Monday at 9am UTC (after plugin sync)
+    - cron: "0 9 * * 1" # Weekly on Monday at 9am UTC (after plugin sync)
   workflow_dispatch:
     inputs:
       target_version:
-        description: 'Specific version to update to (leave empty for latest)'
+        description: "Specific version to update to (leave empty for latest)"
         required: false
 
 jobs:
@@ -67,7 +67,11 @@ jobs:
         if: steps.helm.outputs.needs_update == 'true'
         run: |
           # Update the active (uncommented) HELM_CHART_VERSION line
+          # Update env_variables.sh
           sed -i "s/^HELM_CHART_VERSION=.*/HELM_CHART_VERSION=${{ steps.helm.outputs.latest }}/" env_variables.sh
+
+          # Update deploy/configmap.yaml
+          sed -i "s/^  HELM_CHART_VERSION: .*/  HELM_CHART_VERSION: ${{ steps.helm.outputs.latest }}/" deploy/configmap.yaml
           echo "Updated HELM_CHART_VERSION from ${{ steps.helm.outputs.current }} to ${{ steps.helm.outputs.latest }}"
 
       - name: Sync dynamic plugins
@@ -116,8 +120,8 @@ jobs:
         if: steps.helm.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: 'chore: update RHDH to version ${{ steps.helm.outputs.latest }}'
-          title: '[Auto] Update RHDH to ${{ steps.helm.outputs.latest }}'
+          commit-message: "chore: update RHDH to version ${{ steps.helm.outputs.latest }}"
+          title: "[Auto] Update RHDH to ${{ steps.helm.outputs.latest }}"
           body: |
             ## RHDH Version Update
 


### PR DESCRIPTION
## Summary

Quick bug fix where we were missing the `HELM_CHART_VERSION` from within the `deploy/configmap.yaml` when running the `update-rhdh-version` workflow. This isn't terribly important because the env variable is set by `env_variables.sh` as well. But it is nice to have these be consistent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New plugin support (adds integration for a new RHDH plugin)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD changes

## Related Issues

Closes #(issue number)

## Changes Made

- Adds a line to target the `deploy/configmap.yaml`

## Checklist

### General

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My code follows the project's code conventions
- [ ] I have tested my changes against a real cluster
- [ ] If upgrading RHDH version, verified `values.yaml` is compatible with new chart

### Security

- [ ] **No secrets, tokens, or credentials are included in this PR**
- [ ] Secret templates contain only placeholders (empty strings or `<PLACEHOLDER>`)
- [ ] No hardcoded cluster URLs or API endpoints

### For Plugin Contributions

- [ ] Documentation added in `docs/<plugin-name>.md`
- [ ] Configuration script added in `scripts/config-<plugin-name>-plugin.sh`
- [ ] `config-plugins.sh` updated with new mappings
- [ ] Secret templates updated with new placeholders
- [ ] Resource manifests added (if required)
- [ ] All new scripts are executable (`chmod +x`)

## Testing Notes

Describe how you tested these changes:

1.
2.
3.

## Screenshots (if applicable)

Add screenshots to help explain your changes.
