### PR TITLE
Fix K8S_CLUSTER_URL discovery when running as a K8s job

### DIFF
--- a/deploy/secret-template.yaml
+++ b/deploy/secret-template.yaml
@@ -16,8 +16,10 @@ metadata:
     app.kubernetes.io/component: config
 type: Opaque
 stringData:
-  # Only needed if configuring a DIFFERENT cluster than where Job runs
-  # Leave empty to use in-cluster ServiceAccount authentication
+  # Leave empty when running as a Kubernetes Job (IN_CLUSTER=true).
+  # K8S_CLUSTER_URL will be auto-discovered from the OpenShift Infrastructure CR
+  # (oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}').
+  # When running locally (IN_CLUSTER unset/false), K8S_CLUSTER_URL is required.
   K8S_CLUSTER_TOKEN: ""
   K8S_CLUSTER_URL: ""
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -19,6 +19,17 @@ Manually set up the plugin by:
 3. Mounting the kubeconfig or providing the necessary credentials.
 4. Updating the app-config.yaml to enable the plugin.
 
+**`K8S_CLUSTER_URL` resolution rules:**
+
+| `IN_CLUSTER`  | `K8S_CLUSTER_URL` in Secret | Behaviour                                                         |
+| ------------- | --------------------------- | ----------------------------------------------------------------- |
+| `false`/unset | set                         | Use the provided value                                            |
+| `false`/unset | **empty**                   | **Hard fail** — set it explicitly in your `.env` file             |
+| `true`        | set                         | Use the provided value (overrides auto-discovery)                 |
+| `true`        | **empty**                   | **Auto-discover** from the OpenShift Infrastructure CR (`oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}'`) |
+
+When the setup Job runs with `IN_CLUSTER=true` and `K8S_CLUSTER_URL` is empty, the script queries the cluster's `Infrastructure` object to retrieve the real external API URL (e.g. `https://api.<cluster>:6443`) and writes it into `rhdh-secrets`. This API is accessible to any in-cluster ServiceAccount, so no additional RBAC is required.
+
 App config example:
 
 ```YAML

--- a/scripts/config-kubernetes-plugins.sh
+++ b/scripts/config-kubernetes-plugins.sh
@@ -6,8 +6,28 @@ config_secrets_for_kubernetes_plugins() {
   TOKEN=$(grep 'token:' $PWD/auth/cluster-secrets/service-account-rhdh-token.local.yaml | awk '{print $2}')
   sed -i "s/K8S_CLUSTER_TOKEN:.*/K8S_CLUSTER_TOKEN: $TOKEN/g" $PWD/resources/user-resources/rhdh-secrets.local.yaml
 
-  sed -i "s#K8S_CLUSTER_URL:.*#K8S_CLUSTER_URL: $(echo -n "$K8S_CLUSTER_URL" | base64 -w 0)#g" $PWD/resources/user-resources/rhdh-secrets.local.yaml
-  sed -i "s|K8S_CLUSTER_NAME:.*|K8S_CLUSTER_NAME: $(echo -n "$K8S_CLUSTER_NAME" | base64)|g" $PWD/resources/user-resources/rhdh-secrets.local.yaml
+  # Resolve K8S_CLUSTER_URL: auto-discover ONLY when running as a cluster Job.
+  # Never auto-discover locally — the user could be logged into the wrong cluster.
+  if [[ -z "${K8S_CLUSTER_URL:-}" ]]; then
+    if [[ "${IN_CLUSTER:-false}" == "true" ]]; then
+      echo "K8S_CLUSTER_URL not set — discovering from cluster Infrastructure CR..."
+      K8S_CLUSTER_URL=$(oc get infrastructure cluster \
+        -o jsonpath='{.status.apiServerURL}' 2>/dev/null)
+      if [[ -z "$K8S_CLUSTER_URL" ]]; then
+        echo "ERROR: Could not determine K8S_CLUSTER_URL from cluster. Set it explicitly in the Secret."
+        exit 1
+      fi
+      echo "Discovered K8S_CLUSTER_URL: $K8S_CLUSTER_URL"
+    else
+      echo "ERROR: K8S_CLUSTER_URL is required. Set it in your .env file."
+      exit 1
+    fi
+  fi
+
+  sed -i "s#K8S_CLUSTER_URL:.*#K8S_CLUSTER_URL: $(echo -n "$K8S_CLUSTER_URL" | base64 -w 0)#g" \
+    $PWD/resources/user-resources/rhdh-secrets.local.yaml
+  sed -i "s|K8S_CLUSTER_NAME:.*|K8S_CLUSTER_NAME: $(echo -n "$K8S_CLUSTER_NAME" | base64)|g" \
+    $PWD/resources/user-resources/rhdh-secrets.local.yaml
 }
 
 


### PR DESCRIPTION
## Summary

Fixes a bug where the K8S_CLUSTER_URL isn't discovered when running as a job. This fix resolves that problem by checking if the scripts are running inside the cluster and then querying for the api endpoint of the cluster.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New plugin support (adds integration for a new RHDH plugin)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes

## Related Issues

Closes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Checklist

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My code follows the project's code conventions
- [ ] I have tested my changes against a real cluster
- [ ] If upgrading RHDH version, verified `values.yaml` is compatible with new chart

### Security

- [ ] **No secrets, tokens, or credentials are included in this PR**
- [ ] Secret templates contain only placeholders (empty strings or `<PLACEHOLDER>`)
- [ ] No hardcoded cluster URLs or API endpoints

### For Plugin Contributions

- [ ] Documentation added in `docs/<plugin-name>.md`
- [ ] Configuration script added in `scripts/config-<plugin-name>-plugin.sh`
- [ ] `config-plugins.sh` updated with new mappings
- [ ] Secret templates updated with new placeholders
- [ ] Resource manifests added (if required)
- [ ] All new scripts are executable (`chmod +x`)

## Testing Notes

Describe how you tested these changes:

1.
2.
3.

## Screenshots (if applicable)

Add screenshots to help explain your changes.
